### PR TITLE
Add definition for current HTTP host ABI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Improves experience of commands like `make format` on Windows
+* text=auto eol=lf

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -36,4 +36,8 @@ jobs:
           command: install
           args: witx-cli
 
-      - run: witx docs -o http-host.md witx/http-host.witx
+      - name: Generate markdown
+        run: witx docs -o http-host.md witx/http-host.witx
+
+      - name: Check no diffs from generation
+        run: test -z "$(git status --porcelain)" || (echo "Uncommited files detected, regenerate and commit docs." && exit 1)

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -1,0 +1,39 @@
+# `name` value will appear "as is" in the badge.
+# See https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository
+# yamllint --format github .github/workflows/commit.yaml
+---
+name: "build"
+
+on:
+  push:  # We run tests on non-tagged pushes to main
+    tags: ''
+    branches: main
+    paths-ignore:
+      - '**/*.md'
+  pull_request:  # We also run tests on pull requests targeted at the main branch.
+    branches: main
+    paths-ignore:
+      - '**/*.md'
+  # workflow_dispatch will let us manually trigger the workflow from GitHub actions dashboard.
+  # For example, you can try to build a branch without raising a pull request.
+  # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Pre-commit check
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # No precompiled binaries for witx so we build from crate
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: witx-cli
+
+      - run: witx docs -o http-host.md witx/http-host.witx

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -19,6 +19,9 @@ on:
   # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:
 
+env:
+  WITX_CLI_VERSION: 0.9.1
+
 jobs:
   check:
     name: Pre-commit check
@@ -28,13 +31,22 @@ jobs:
       - uses: actions/checkout@v3
 
       # No precompiled binaries for witx so we build from crate
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-witx-${{ env.WITX_CLI_VERSION }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
       - uses: actions-rs/cargo@v1
         with:
           command: install
-          args: witx-cli
+          args: --version ${{ env.WITX_CLI_VERSION }} witx-cli
 
       - name: Generate markdown
         run: witx docs -o http-host.md witx/http-host.witx

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: docs
+docs:
+	@witx docs -o http-host.md witx/http-host.witx

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ characters.
 ### Host ABI
 
 The [host ABI](./http-host.md) defines the functions that the host makes available to
-middleware. Frameworks adding support for http-wasm middleware must expose the
-functions defined in the ABI to loaded Wasm binaries for them to function.
+middleware. Frameworks adding support for http-wasm middleware must export the
+functions defined in the ABI to guest Wasm binaries for them to function.
 
 [1]: https://webassembly.org/
 [2]: https://wazero.io

--- a/README.md
+++ b/README.md
@@ -61,8 +61,20 @@ process can safely run code defined externally.
 
 ## Application Binary Interface (ABI)
 
-The HTTP middleware ABI is not yet defined, but will be after practice. Follow
-this repository for updates.
+The HTTP middleware ABI is currently being defined. Follow this repository for updates.
+
+### Common notes
+
+- Parameters of type `string` expand to two parameters of type `u32`, the first being
+the pointer to the contents of the string and the second being the number of bytes.
+Note that for unicode strings, the number of bytes is larger than the number of
+characters.
+
+### Host ABI
+
+The [host ABI](./http-host.md) defines the functions that the host makes available to
+middleware. Frameworks adding support for http-wasm middleware must expose the
+functions defined in the ABI to loaded Wasm binaries for them to function.
 
 [1]: https://webassembly.org/
 [2]: https://wazero.io

--- a/http-host.md
+++ b/http-host.md
@@ -1,0 +1,16 @@
+# Types
+# Modules
+## <a href="#http" name="http"></a> http
+### Imports
+### Functions
+
+---
+
+#### <a href="#log" name="log"></a> `log(msg: string)`
+Log a message to the host's logs.
+
+##### Params
+- <a href="#log.msg" name="log.msg"></a> `msg`: `string`
+The message to log, as a UTF-8 encoded string.
+
+##### Results

--- a/witx/http-host.witx
+++ b/witx/http-host.witx
@@ -1,0 +1,12 @@
+;; HTTP host ABI
+;;
+;; The HTTP host ABI defines functions available to HTTP middleware to interact
+;; with the host process.
+
+(module $http
+  ;;; Log a message to the host's logs.
+  (@interface func (export "log")
+    ;;; The message to log, as a UTF-8 encoded string.
+    (param $msg string)
+  )
+)


### PR DESCRIPTION
The goal of this PR is to document what is in https://github.com/http-wasm/http-wasm-guest-tinygo/blob/main/imports.go, not to be a full HTTP host ABI :)