### PR TITLE
Renames wasm module from "http" to "http-handler"

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -48,7 +48,7 @@ jobs:
           args: --version ${{ env.WITX_CLI_VERSION }} witx-cli
 
       - name: Generate markdown
-        run: witx docs -o http-host.md witx/http-host.witx
+        run: witx docs -o http-handler.md witx/http-handler.witx
 
       - name: Check no diffs from generation
         run: test -z "$(git status --porcelain)" || (echo "Uncommited files detected, regenerate and commit docs." && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: docs
 docs:
-	@witx docs -o http-host.md witx/http-host.witx
+	@witx docs -o http-handler.md witx/http-handler.witx

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ updates.
 The [handler ABI](./http-handler.md) defines the functions that the host makes
 available to middleware. Frameworks adding support for http-handler middleware
 must export the functions defined in the ABI to guest Wasm binaries for them
-to function. Meanwhile, guests must to minimally export its memory as "memory".
+to function. Meanwhile, guests must minimally export memory as "memory".
 
 [1]: https://github.com/http-wasm
 [2]: https://webassembly.org/

--- a/README.md
+++ b/README.md
@@ -16,16 +16,12 @@ updates.
   the number of bytes. *Note* that for unicode strings, the number of bytes is
   larger than the number of characters.
 
-### Host ABI
+### Handler ABI
 
-The [host ABI](./http-host.md) defines the functions that the host makes
-available to middleware. Frameworks adding support for http-wasm middleware
+The [handler ABI](./http-handler.md) defines the functions that the host makes
+available to middleware. Frameworks adding support for http-handler middleware
 must export the functions defined in the ABI to guest Wasm binaries for them
-to function.
-
-### Guest ABI
-
-The guest must to minimally export its memory as "memory".
+to function. Meanwhile, guests must to minimally export its memory as "memory".
 
 [1]: https://github.com/http-wasm
 [2]: https://webassembly.org/

--- a/http-handler.md
+++ b/http-handler.md
@@ -1,6 +1,6 @@
 # Types
 # Modules
-## <a href="#http" name="http"></a> http
+## <a href="#http-handler" name="http-handler"></a> http-handler
 ### Imports
 ### Functions
 

--- a/witx/http-handler.witx
+++ b/witx/http-handler.witx
@@ -1,9 +1,9 @@
-;; HTTP host ABI
+;; HTTP handler ABI
 ;;
-;; The HTTP host ABI defines functions available to HTTP middleware to interact
-;; with the host process.
+;; The HTTP handler ABI defines functions invoked on an HTTP server handling
+;; a client request.
 
-(module $http
+(module $http-handler
   ;;; Log a message to the host's logs.
   (@interface func (export "log")
     ;;; The message to log, as a UTF-8 encoded string.


### PR DESCRIPTION
This follows conventions similar to WASI where the ABI isn't named based on which side (host vs guest), but rather which functionality it is implementing. In this case, we should dodge "http" as it will lead to confusion later when things like HTTP client ABIs start becoming defined. "http-handler" is a nice way for us to describe a synchronous server handler.

https://github.com/WebAssembly/wasi-filesystem/issues/46#issuecomment-1143873563