### PR TITLE
Reworks types to be more like how they look in TinyGo

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -51,4 +51,4 @@ jobs:
         run: witx docs -o http-handler.md witx/http-handler.witx
 
       - name: Check no diffs from generation
-        run: test -z "$(git status --porcelain)" || (echo "Uncommited files detected, regenerate and commit docs." && exit 1)
+        run: test -z "$(git status --porcelain)" || (echo "Uncommitted files detected, regenerate and commit docs." && exit 1)

--- a/http-handler.md
+++ b/http-handler.md
@@ -1,16 +1,47 @@
 # Types
+## <a href="#ptr" name="ptr"></a> `ptr`: `Pointer<u8>`
+ptr is a linear memory byte offset.
+
+Size: 4
+
+Alignment: 4
+
+## <a href="#size" name="size"></a> `size`: `u32`
+size is a size in bytes to read or write from a memory offset.
+
+Size: 4
+
+Alignment: 4
+
 # Modules
 ## <a href="#http-handler" name="http-handler"></a> http-handler
 ### Imports
+#### Memory
 ### Functions
 
 ---
 
-#### <a href="#log" name="log"></a> `log(msg: string)`
-Log a message to the host's logs.
+#### <a href="#log" name="log"></a> `log(message: ptr, message_len: size)`
+FuncLog logs a message to the host's logs.
+
+For example, if parameters are message=8, message_len=2, this function
+would log the message "error".
+
+```
+              message_len
+           +--------------+
+           |              |
+[]byte{?, 'e', 'r', 'o', 'r', ?}
+ message --^
+```
+
+Note: A host who fails to log the message will trap (aka panic, "unreachable" instruction).
 
 ##### Params
-- <a href="#log.msg" name="log.msg"></a> `msg`: `string`
-The message to log, as a UTF-8 encoded string.
+- <a href="#log.message" name="log.message"></a> `message`: [`ptr`](#ptr)
+The memory offset of the UTF-8 encoded message to log.
+
+- <a href="#log.message_len" name="log.message_len"></a> `message_len`: [`size`](#size)
+The possibly zero length of the message in bytes.
 
 ##### Results

--- a/witx/http-handler.witx
+++ b/witx/http-handler.witx
@@ -2,11 +2,41 @@
 ;;
 ;; The HTTP handler ABI defines functions invoked on an HTTP server handling
 ;; a client request.
+;;
+;; Note: This specification only uses numeric types, defined in WebAssembly
+;; Core Specification 1.0. For example, a string is passed as two parameters:
+;; $ptr and $size corresponding to its segment in linear memory.
+
+;;; ptr is a linear memory byte offset.
+(typename $ptr (@witx pointer u8))
+
+;;; size is a size in bytes to read or write from a memory offset.
+(typename $size u32)
 
 (module $http-handler
-  ;;; Log a message to the host's logs.
+  ;;; Memory is required for string parameters as they are passed as a memory
+  ;;; offset and size (in bytes). It is also used for message bodies, which are
+  ;;; parameterized the same way.
+  (import "memory" (memory))
+
+  ;;; FuncLog logs a message to the host's logs.
+  ;;;
+  ;;; For example, if parameters are message=8, message_len=2, this function
+  ;;; would log the message "error".
+  ;;;
+  ;;; ```
+  ;;;	              message_len
+  ;;;	           +--------------+
+  ;;;	           |              |
+  ;;;	[]byte{?, 'e', 'r', 'o', 'r', ?}
+  ;;;  message --^
+  ;;; ```
+  ;;;
+  ;;; Note: A host who fails to log the message will trap (aka panic, "unreachable" instruction).
   (@interface func (export "log")
-    ;;; The message to log, as a UTF-8 encoded string.
-    (param $msg string)
+    ;;; The memory offset of the UTF-8 encoded message to log.
+    (param $message $ptr)
+    ;;; The possibly zero length of the message in bytes.
+    (param $message_len $size)
   )
 )


### PR DESCRIPTION
This prefers ptr/size vs implicit conversion of string. This is helpful because the same is usable for raw binary segments, too. This also migrates in docs from http-wasm-guest-tinygo. Once this is approved, I'll do the rest.