### PR TITLE
Adds get-request-header

### DIFF
--- a/http-handler.abi.md
+++ b/http-handler.abi.md
@@ -1,3 +1,28 @@
+# Types
+
+## <a href="#buf_limit" name="buf_limit"></a> `buf-limit`: `u32`
+
+  The possibly zero maximum length of a result value to write in bytes.
+  If the actual value is larger than this, nothing is written to memory.
+  A function that accepts this parameter returns `maybe-len`.
+
+Size: 4, Alignment: 4
+
+## <a href="#maybe_len" name="maybe_len"></a> `maybe-len`: `u64`
+
+  maybe-len expresses a possibly nil length in bytes. To retain signature
+  compatability with WebAssembly Core Specification 1.0, two u32 values are
+  represented as a single u64 in the following order:
+  
+  - ok: zero if the value does not exist and one if it does.
+  - len: possibly zero length in bytes of the value.
+  
+  If the result is zero, there is no value. Otherwise, the lower 32-bits are
+  `len`. For example, in WebAssembly `i32.wrap_i64` unpacks the lower 32-bits
+  as would casting in most languages (ex `uint32(maybe-len)` in Go).
+
+Size: 8, Alignment: 8
+
 # Functions
 
 ----
@@ -12,4 +37,24 @@
 
 - <a href="#log.message" name="log.message"></a> `message`: `u32`
 - <a href="#log.message_len" name="log.message_len"></a> `message-len`: `u32`
+
+----
+
+#### <a href="#get_request_header" name="get_request_header"></a> `get-request-header` 
+
+  writes a header value to memory if it exists and isn't larger than
+  `buf-limit`. The result is `1<<32|len`, where `len` is the bytes written,
+  or zero if the header doesn't exist.
+  
+  Note: A host who fails to get the request header will trap (aka panic,
+  "unreachable" instruction).
+##### Params
+
+- <a href="#get_request_header.name" name="get_request_header.name"></a> `name`: `u32`
+- <a href="#get_request_header.name_len" name="get_request_header.name_len"></a> `name-len`: `u32`
+- <a href="#get_request_header.buf" name="get_request_header.buf"></a> `buf`: `u32`
+- <a href="#get_request_header.buf_limit" name="get_request_header.buf_limit"></a> `buf-limit`: [`buf-limit`](#buf_limit)
+##### Results
+
+- [`maybe-len`](#maybe_len)
 

--- a/http-handler.wit.md
+++ b/http-handler.wit.md
@@ -6,6 +6,45 @@ the functions defined in the ABI to guest Wasm binaries for them to function.
 Meanwhile, guests must minimally export memory as "memory". Further details are
 described below.
 
+## Types
+
+### `buf-limit`
+
+```wit
+/// The possibly zero maximum length of a result value to write in bytes.
+/// If the actual value is larger than this, nothing is written to memory.
+/// A function that accepts this parameter returns `maybe-len`.
+type buf-limit = u32
+```
+
+This parameter supports the most common case of retrieving a header value by
+name. However, there are some subtle use cases possible, particularly helpful
+for WebAssembly performance:
+
+- re-using a buffer for multiple header reads (`buf`).
+- growing a buffer only when needed (retry with larger `buf-limit`).
+- avoiding copying invalidly large header values (`buf-limit`).
+- determining if a header exists without copying it (`buf-limit=0`).
+
+### `maybe-len`
+
+```wit
+/// maybe-len expresses a possibly nil length in bytes. To retain signature
+/// compatability with WebAssembly Core Specification 1.0, two u32 values are
+/// represented as a single u64 in the following order:
+///
+///   - ok: zero if the value does not exist and one if it does.
+///   - len: possibly zero length in bytes of the value.
+///
+/// If the result is zero, there is no value. Otherwise, the lower 32-bits are
+/// `len`. For example, in WebAssembly `i32.wrap_i64` unpacks the lower 32-bits
+/// as would casting in most languages (ex `uint32(maybe-len)` in Go).
+type maybe-len = u64
+```
+
+For example, if a value exists and is "01234567", then `len=8`, so `maybe-len`
+is `i64(1<<32 | 8)` or `i64(4294967304)`.
+
 ## Guest exports
 
 The http-handler guest is wasm that takes action on an incoming server request.
@@ -59,4 +98,55 @@ log the message "error".
            |                  |
 []byte{?, 'e', 'r', r', 'o', 'r', ?}
  message --^
+```
+
+### `get-request-header`
+
+```wit
+/// writes a header value to memory if it exists and isn't larger than
+/// `buf-limit`. The result is `1<<32|len`, where `len` is the bytes written,
+/// or zero if the header doesn't exist.
+///
+/// Note: A host who fails to get the request header will trap (aka panic,
+/// "unreachable" instruction).
+get-request-header: func(
+    /// The memory offset of the UTF-8 encoded header name, which the host
+    /// looks up case insensitively. Ex. "Content-Length" or "content-length".
+    name: u32,
+    /// The length of the header name in bytes.
+    name-len: u32,
+    /// The memory offset of the UTF-8 encoded header value, if a value exists
+    /// and is not larger than `buf-limit` bytes.
+    buf: u32,
+    /// The possibly zero maximum length of the header value to write in bytes.
+    /// If the actual value is larger than this, nothing is written to memory.
+    buf-limit: buf-limit,
+) -> maybe-len
+```
+
+For example, if parameters name=1 and name_len=4, this function would read the
+header name "ETag".
+
+```
+               name-len
+           +--------------+
+           |              |
+[]byte{?, 'E', 'T', 'a', 'g', ?}
+    name --^
+```
+
+If there was no `ETag` header, the result would be i64(0) and the user doesn't
+need to read memory.
+
+If the `buf-limit` parameter was 7, nothing would be written to memory. The
+caller would decide whether to retry the request with a higher limit.
+
+If parameters buf=16 and buf_limit=128, and there was a value "01234567", the
+result would be `1<<32|8` and the value written like so:
+```
+                         u32(maybe-len) == 8
+                +----------------------------------+
+                |                                  |
+[]byte{ 0..15, '0', '1', '2', '3', '4', '5', '6', '7', ?, .. }
+          buf --^
 ```

--- a/http-handler.wit.md
+++ b/http-handler.wit.md
@@ -144,7 +144,7 @@ caller would decide whether to retry the request with a higher limit.
 If parameters buf=16 and buf_limit=128, and there was a value "01234567", the
 result would be `1<<32|8` and the value written like so:
 ```
-                         u32(maybe-len) == 8
+                         u32(1<<32|8) == 8
                 +----------------------------------+
                 |                                  |
 []byte{ 0..15, '0', '1', '2', '3', '4', '5', '6', '7', ?, .. }


### PR DESCRIPTION
This adds get-request-header and extracts maybe-len as a type so it can be re-used for response headers or body properties