### PR TITLE
Synchronizes ABI with proof-of-concept

### DIFF
--- a/http-handler.abi.md
+++ b/http-handler.abi.md
@@ -91,3 +91,46 @@ Size: 8, Alignment: 8
 - <a href="#set_path.path" name="set_path.path"></a> `path`: `u32`
 - <a href="#set_path.path_len" name="set_path.path_len"></a> `path-len`: `u32`
 
+----
+
+#### <a href="#next" name="next"></a> `next` 
+
+  calls a downstream handler and blocks until it is finished processing the
+  response. This is an alternative to `send_response`.
+  
+  Note: A host who fails to dispatch to or invoke the next handler will trap
+  (aka panic, "unreachable" instruction).
+
+----
+
+#### <a href="#set_response_header" name="set_response_header"></a> `set-response-header` 
+
+  Overwrites a response header with a given name to a value read from memory.
+  
+  Note: A host who fails to set the response header will trap (aka panic,
+  "unreachable" instruction).
+##### Params
+
+- <a href="#set_response_header.name" name="set_response_header.name"></a> `name`: `u32`
+- <a href="#set_response_header.name_len" name="set_response_header.name_len"></a> `name-len`: `u32`
+- <a href="#set_response_header.value" name="set_response_header.value"></a> `value`: `u32`
+- <a href="#set_response_header.value_len" name="set_response_header.value_len"></a> `value-len`: `u32`
+
+----
+
+#### <a href="#send_response" name="send_response"></a> `send-response` 
+
+  sends the HTTP response with a given status code and optional body. This is
+  an alternative to dispatching to the `next` handler.
+  
+  Note: The "Content-Length" header is set to `body-len` when non-zero. If
+  you need to set "Content-Length: 0", call `set-response-header` first.
+  
+  Note: A host who fails to send the response will trap (aka panic,
+  "unreachable" instruction).
+##### Params
+
+- <a href="#send_response.status_code" name="send_response.status_code"></a> `status-code`: `u32`
+- <a href="#send_response.body" name="send_response.body"></a> `body`: `u32`
+- <a href="#send_response.body_len" name="send_response.body_len"></a> `body-len`: `u32`
+

--- a/http-handler.wit.md
+++ b/http-handler.wit.md
@@ -124,7 +124,7 @@ get-request-header: func(
 ) -> maybe-len
 ```
 
-For example, if parameters name=1 and name_len=4, this function would read the
+For example, if parameters name=1 and name-len=4, this function would read the
 header name "ETag".
 
 ```
@@ -211,3 +211,70 @@ set the path to "/a".
 []byte{?, '/', 'a', ?}
     path --^
 ```
+
+### `next`
+
+```wit
+/// calls a downstream handler and blocks until it is finished processing the
+/// response. This is an alternative to `send_response`.
+///
+/// Note: A host who fails to dispatch to or invoke the next handler will trap
+/// (aka panic, "unreachable" instruction).
+next: func()
+```
+
+### `set-response-header`
+
+```wit
+/// Overwrites a response header with a given name to a value read from memory.
+///
+/// Note: A host who fails to set the response header will trap (aka panic,
+/// "unreachable" instruction).
+set-response-header: func(
+    /// The memory offset of the UTF-8 encoded header name.
+    name: u32,
+    /// The possibly zero length of the UTF-8 encoded header name, in bytes.
+    name-len: u32,
+    /// The memory offset of the UTF-8 encoded header value.
+    value: u32,
+    /// The possibly zero length of the UTF-8 encoded header value, in bytes.
+    value-len: u32,
+)
+```
+
+For example, if parameters are name=1, name-len=4, value=8, value-len=1,
+this function would set the response header "ETag: 1".
+
+```
+               name-len             value-len
+           +--------------+             +
+           |              |             |
+[]byte{?, 'E', 'T', 'a', 'g', ?, ?, ?, '1', ?}
+    name --^                            ^
+                                value --+
+```
+
+### `send-response`
+
+```wit
+/// sends the HTTP response with a given status code and optional body. This is
+/// an alternative to dispatching to the `next` handler.
+///
+/// Note: The "Content-Length" header is set to `body-len` when non-zero. If
+/// you need to set "Content-Length: 0", call `set-response-header` first.
+///
+/// Note: A host who fails to send the response will trap (aka panic,
+/// "unreachable" instruction).
+send-response: func(
+    /// The HTTP status code. Ex. 200
+    status-code: u32,
+    /// The memory offset of the response body.
+    body: u32,
+    /// The possibly zero length of the response body, in bytes.
+    body-len: u32,
+)
+```
+
+For example, if parameters are status_code=401, body=1, body-len=0, this
+function sends the HTTP status code 401 with neither a body nor a
+"Content-Length" header.


### PR DESCRIPTION
This completes documenting the ABI used in the current proof-of-concept benchmarks. Note that the ABI will change further to support coraza use cases, notably response body filtering. However, it is still a good idea to synchronize meanwhile, hence this PR.

See https://github.com/http-wasm/components-contrib/blob/httpwasm/middleware/http/wasm/benchmark_test.go